### PR TITLE
fix rename ReadOnly to ReadOnlyRoute

### DIFF
--- a/api/v1/routes/PublicReadRoute.php
+++ b/api/v1/routes/PublicReadRoute.php
@@ -15,7 +15,7 @@
 
 namespace AMCActivities\api\v1\routes;
 
-abstract class PublicReadRoute extends ReadOnly
+abstract class PublicReadRoute extends ReadOnlyRoute
 {
     public function getItemsPermissionsCheck(\WP_REST_Request $request)
     {

--- a/api/v1/routes/ReadOnlyRoute.php
+++ b/api/v1/routes/ReadOnlyRoute.php
@@ -19,7 +19,7 @@ use AMCActivities\api\v1\interfaces\Route;
 use AMCActivities\api\v1\responses\Error;
 use AMCActivities\api\v1\responses\Response;
 
-abstract class ReadOnly implements Route
+abstract class ReadOnlyRoute implements Route
 {
     /**
      * @inheritdoc

--- a/includes/AMCActivitiesClass.php
+++ b/includes/AMCActivitiesClass.php
@@ -109,7 +109,7 @@ class AMCActivitiesClass
         require_once plugin_dir_path(dirname(__FILE__)) . 'api/v1/interfaces/Route.php';
         require_once plugin_dir_path(dirname(__FILE__)) . 'api/v1/responses/Response.php';
         require_once plugin_dir_path(dirname(__FILE__)) . 'api/v1/responses/Error.php';
-        require_once plugin_dir_path(dirname(__FILE__)) . 'api/v1/routes/ReadOnly.php';
+        require_once plugin_dir_path(dirname(__FILE__)) . 'api/v1/routes/ReadOnlyRoute.php';
         require_once plugin_dir_path(dirname(__FILE__)) . 'api/v1/routes/PublicReadRoute.php';
         require_once plugin_dir_path(dirname(__FILE__)) . 'api/v1/routes/Activities.php';
         require_once plugin_dir_path(dirname(__FILE__)) . 'api/v1/Boot.php';


### PR DESCRIPTION
readonly is a reserved keyword in PHP 8.1. Any existing classes or other symbols that use the name readonly (case insensitive) will result in a syntax error in PHP 8.1.

https://php.watch/versions/8.1/readonly#:~:text=readonly%20is%20a%20reserved%20keyword,syntax%20error%20in%20PHP%208.1.

Hey @marty-jensen, full disclaimer, I am not a php developer. I reproduce the error below using a vanilla wordpress install using my mac and MAMP, and tried the rename fix and it seems to work. 
```
[02-May-2023 18:49:35 UTC] PHP Parse error:  syntax error, unexpected token "readonly", expecting identifier in /Applications/MAMP/htdocs/wp-content/plugins/amc-activities-shortcode/api/v1/routes/ReadOnly.php on line 22
```

Not sure your best pracitce for fixes and PR but thought I will at least start the conversation here. 

This PR should fix https://github.com/graybirchsolutions/amc-activities-shortcode/issues/16