### PR TITLE
add activation check for_allow_url_fopen

### DIFF
--- a/amc-activities-shortcode.php
+++ b/amc-activities-shortcode.php
@@ -42,6 +42,18 @@ define('AMC_ACTIVITIES_BASE_EVENT_URL', 'https://activities.outdoors.org/search/
 
 define('AMC_API_ROOT', 'AMCActivities/1.0');
 
+register_activation_hook(__FILE__, 'plugin_activation_checks' );
+
+function check_allow_url_fopen() {
+    if ( ! ini_get( 'allow_url_fopen' ) ) {
+        wp_die( 'The allow_url_fopen setting is not enabled.' );
+    }
+}
+
+function plugin_activation_checks() {
+    check_allow_url_fopen();
+}
+
 /**
  * The core plugin class that is used to define internationalization,
  * admin-specific hooks, and public-facing site hooks.


### PR DESCRIPTION
I tested it by modify `php.ini` file and alternating between
allow_url_fopen = On
allow_url_fopen = Off
When it is Off, i get the following error "The allow_url_fopen setting is not enabled." (screenshot attached)
![WordPress_›_Error](https://user-images.githubusercontent.com/722794/235775243-e7aeac51-f984-46b1-b626-c7919c8cfe26.png)

